### PR TITLE
feat: Add slide-over example

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,12 @@
               Countdown Clock
             </span>
           </a>
+          <a href="./misc/slide-over.html"
+            class="group flex items-center px-3 py-2 text-sm font-medium text-gray-600 rounded-md hover:text-gray-900 hover:bg-gray-50">
+            <span class="truncate">
+              Slide-Over
+            </span>
+          </a>
         </div>
 
     </nav>

--- a/misc/slide-over.html
+++ b/misc/slide-over.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="../favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fetching | Alpine.js Examples</title>
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+
+  <body>
+    <div class="max-w-lg m-auto flex justify-between items-center mb-6">
+      <a href="../index.html" class="hover:opacity-75">
+        <h1>Alpine.js Examples</h1>
+      </a>
+    </div>
+
+    <main x-data="{open: false}">
+      <nav
+        class="absolute top-0 left-0 p-4 bg-gray-50 h-screen"
+        x-show.transition="open"
+      >
+        <ol @click.away="open = false">
+          <li>Entry 1</li>
+          <li>Entry 2</li>
+          <li>Entry 3</li>
+        </ol>
+        <p>Click anywhere outside the overlay to close it again</p>
+      </nav>
+
+      <section>
+        <h2>Slide-Over</h2>
+        <button @click="open = !open">
+          Click me to <span x-text="open ? 'hide' : 'reveal'"></span> the
+          slide-over menu
+        </button>
+      </section>
+    </main>
+
+    <script src="//unpkg.com/alpinejs" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
Simple slide-over menu that uses @click.away to close on outside clicks, and demonstrates state-dependent button text with x-text.

Signed-off-by: Tobias Grasse <mail@tobias-grasse.net>